### PR TITLE
sslParameters client-auth for Akka's future use

### DIFF
--- a/ssl-config-core/src/main/resources/reference.conf
+++ b/ssl-config-core/src/main/resources/reference.conf
@@ -6,6 +6,7 @@ ssl-config {
   logger = "com.typesafe.sslconfig.util.NoopLogger"
 
   # Whether we should use the default JVM SSL configuration or not
+  # When false additional configuration will be applied on the context (as configured in ssl-config).
   default = false
 
   # The ssl protocol to use
@@ -36,6 +37,18 @@ ssl-config {
   # If non null, should be the fully qualify classname of a class that imlpements HostnameVerifier,
   # otherwise the default will be used
   hostnameVerifierClass = null
+
+  sslParameters {
+    # translates to a setNeedClientAuth / setWantClientAuth calls
+    # "default" – leaves the (which for JDK8 means wantClientAuth and needClientAuth are set to false.)
+    # "none"    – `setNeedClientAuth(false)`
+    # "want"    – `setWantClientAuth(true)`
+    # "need"    – `setNeedClientAuth(true)`
+    clientAuth = "default"
+
+    # protocols (names)
+    protocols = []
+  }
 
   # Configuration for the key manager
   keyManager {

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/DisabledComplainingHostnameVerifier.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/DisabledComplainingHostnameVerifier.scala
@@ -22,7 +22,8 @@ class DisabledComplainingHostnameVerifier(mkLogger: LoggerFactory) extends Hostn
     if (!hostNameMatches) {
       // TODO fix config paths
       val msg =
-        s"Hostname verification failed on hostname $hostname, but the connection was accepted because ws.ssl.disableHostnameVerification is enabled. " +
+        s"Hostname verification failed on hostname $hostname, " +
+          "but the connection was accepted because ssl-config.loose.disableHostnameVerification is enabled. " +
           "Please fix the X.509 certificate on the host to remove this warning."
       logger.warn(msg)
     }

--- a/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/ConfigSSLContextBuilderSpec.scala
+++ b/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/ConfigSSLContextBuilderSpec.scala
@@ -155,7 +155,7 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
       val certificateData = CertificateGenerator.toPEM(certificate)
 
       val trustStoreConfig = TrustStoreConfig(storeType = "PEM", data = Some(certificateData), filePath = None)
-      val trustManagerConfig = TrustManagerConfig(trustStoreConfigs = Seq(trustStoreConfig))
+      val trustManagerConfig = TrustManagerConfig(trustStoreConfigs = List(trustStoreConfig))
 
       val disabledSignatureAlgorithms = Set(AlgorithmConstraint("md5"))
       val disabledKeyAlgorithms = Set(AlgorithmConstraint("RSA", Some(LessThan(1024))))
@@ -223,7 +223,7 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
       val disabledKeyAlgorithms = Set(AlgorithmConstraint("RSA", Some(Equal(1024))))
       //val disabledKeyAlgorithms = Set[AlgorithmConstraint]()
       val tsc = TrustStoreConfig(storeType = "PEM", data = Some(data), filePath = None)
-      val trustManagerConfig = TrustManagerConfig(trustStoreConfigs = Seq(tsc))
+      val trustManagerConfig = TrustManagerConfig(trustStoreConfigs = List(tsc))
 
       val info = SSLConfig(trustManagerConfig = trustManagerConfig)
       val builder = new ConfigSSLContextBuilder(mkLogger, info, keyManagerFactory, trustManagerFactory)
@@ -254,7 +254,7 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
       val trustManagerFactory = mock[TrustManagerFactoryWrapper]
 
       val ksc = KeyStoreConfig(filePath = Some("path"), password = Some(password))
-      val keyManagerConfig = KeyManagerConfig(keyStoreConfigs = Seq(ksc))
+      val keyManagerConfig = KeyManagerConfig(keyStoreConfigs = List(ksc))
 
       val info = SSLConfig(keyManagerConfig = keyManagerConfig)
       val builder = new ConfigSSLContextBuilder(mkLogger, info, keyManagerFactory, trustManagerFactory)
@@ -284,7 +284,7 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
       val trustManagerFactory = mock[TrustManagerFactoryWrapper]
 
       val ksc = KeyStoreConfig(filePath = Some("path"), password = Some(password))
-      val keyManagerConfig = KeyManagerConfig(keyStoreConfigs = Seq(ksc))
+      val keyManagerConfig = KeyManagerConfig(keyStoreConfigs = List(ksc))
 
       val info = SSLConfig(keyManagerConfig = keyManagerConfig)
       val builder = new ConfigSSLContextBuilder(mkLogger, info, keyManagerFactory, trustManagerFactory)
@@ -319,7 +319,7 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
       val disabledKeyAlgorithms = Set(AlgorithmConstraint("RSA", Some(LessThan(1024))))
       //val disabledKeyAlgorithms = Set[AlgorithmConstraint]()
       val tsc = TrustStoreConfig(storeType = "PEM", data = Some(data), filePath = None)
-      val trustManagerConfig = TrustManagerConfig(trustStoreConfigs = Seq(tsc))
+      val trustManagerConfig = TrustManagerConfig(trustStoreConfigs = List(tsc))
 
       val info = SSLConfig(trustManagerConfig = trustManagerConfig)
       val builder = new ConfigSSLContextBuilder(mkLogger, info, keyManagerFactory, trustManagerFactory)
@@ -337,7 +337,7 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
       val trustManagerFactory = mock[TrustManagerFactoryWrapper]
 
       val ksc = KeyStoreConfig(storeType = "PKCS12", filePath = Some("path"))
-      val keyManagerConfig = KeyManagerConfig(keyStoreConfigs = Seq(ksc))
+      val keyManagerConfig = KeyManagerConfig(keyStoreConfigs = List(ksc))
       val sslConfig = SSLConfig(keyManagerConfig = keyManagerConfig)
 
       val builder = new ConfigSSLContextBuilder(mkLogger, sslConfig, keyManagerFactory, trustManagerFactory)
@@ -350,7 +350,7 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
       val trustManagerFactory = mock[TrustManagerFactoryWrapper]
 
       val ksc = KeyStoreConfig(storeType = "PKCS12", filePath = Some("path"), password = Some("password"))
-      val keyManagerConfig = KeyManagerConfig(keyStoreConfigs = Seq(ksc))
+      val keyManagerConfig = KeyManagerConfig(keyStoreConfigs = List(ksc))
       val sslConfig = SSLConfig(keyManagerConfig = keyManagerConfig)
 
       val builder = new ConfigSSLContextBuilder(mkLogger, sslConfig, keyManagerFactory, trustManagerFactory)


### PR DESCRIPTION
**Goal:** Moving in the general direction of being able to configure SSLParameters declaratively in ssl-config