### PR TITLE
OSGify JARs Issue #31

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import com.typesafe.sbt.osgi.SbtOsgi
 import sbtrelease.ReleasePlugin
 import com.typesafe.sbt.pgp.PgpKeys.publishSigned
 
@@ -20,8 +21,11 @@ lazy val sslConfigCore = project.in(file("ssl-config-core"))
       scalaBinaryVersion.value match {
         case "2.10" => Seq.empty[ModuleID]
         case _      => Seq(Library.parserCombinators)
-      })
-  ).enablePlugins(ReleasePlugin)
+      }),
+    osgiSettings,
+    OsgiKeys.bundleSymbolicName := s"${organization.value}.sslconfig",
+    OsgiKeys.exportPackage := Seq(s"com.typesafe.sslconfig.*;version=${version.value}")
+  ).enablePlugins(ReleasePlugin, SbtOsgi)
 
 lazy val documentation = project.in(file("documentation"))
   .settings(dontPublishSettings: _*)
@@ -31,8 +35,12 @@ lazy val sslConfigAkka = project.in(file("ssl-config-akka"))
   .settings(commonSettings: _*)
   .settings(
     name := "ssl-config-akka",
-    libraryDependencies ++= Dependencies.sslConfigAkka
-  ).enablePlugins(ReleasePlugin)
+    libraryDependencies ++= Dependencies.sslConfigAkka,
+    osgiSettings,
+    OsgiKeys.bundleSymbolicName := s"${organization.value}.sslconfig.akka",
+    OsgiKeys.requireBundle := Seq(s"""com.typesafe.sslconfig;bundle-version="${version.value}""""),
+    OsgiKeys.exportPackage := Seq("com.typesafe.sslconfig.akka.*")
+  ).enablePlugins(ReleasePlugin, SbtOsgi)
 
 //lazy val sslConfigPlay = project.in(file("ssl-config-play"))
 //  .dependsOn(sslConfigCore)

--- a/build.sbt
+++ b/build.sbt
@@ -26,12 +26,7 @@ lazy val sslConfigCore = project.in(file("ssl-config-core"))
     osgiSettings,
     OsgiKeys.bundleSymbolicName := s"${organization.value}.sslconfig",
     OsgiKeys.exportPackage := Seq(s"com.typesafe.sslconfig.*;version=${version.value}"),
-    OsgiKeys.requireBundle := (
-      scalaBinaryVersion.value match {
-        case "2.10" => Nil
-        case _ => Seq(s"""org.scala-lang.modules.scala-parser-combinators;bundle-version="${Version.parserCombinators}"""")
-      }
-    )
+    OsgiKeys.importPackage := Seq("!sun.misc", "!sun.security.*", configImport(), "*")
   ).enablePlugins(ReleasePlugin, SbtOsgi)
 
 lazy val documentation = project.in(file("documentation"))
@@ -45,8 +40,8 @@ lazy val sslConfigAkka = project.in(file("ssl-config-akka"))
     libraryDependencies ++= Dependencies.sslConfigAkka,
     osgiSettings,
     OsgiKeys.bundleSymbolicName := s"${organization.value}.sslconfig.akka",
-    OsgiKeys.requireBundle := Seq(s"""com.typesafe.sslconfig;bundle-version="${version.value}""""),
-    OsgiKeys.exportPackage := Seq("com.typesafe.sslconfig.akka.*")
+    OsgiKeys.exportPackage := Seq(s"com.typesafe.sslconfig.akka.*;version=${version.value}"),
+    OsgiKeys.requireBundle := Seq(s"""com.typesafe.sslconfig;bundle-version="${version.value}"""")
   ).enablePlugins(ReleasePlugin, SbtOsgi)
 
 //lazy val sslConfigPlay = project.in(file("ssl-config-play"))
@@ -64,3 +59,8 @@ lazy val root = project.in(file("."))
 //    sslConfigPlay,
     documentation)
   .settings(dontPublishSettings: _*)
+
+
+// JDK6: 1.2.0, Akka 2.4: 1.3.0
+def configImport(packageName: String = "com.typesafe.config.*") = versionedImport(packageName, "1.2.0", "1.4.0")
+def versionedImport(packageName: String, lower: String, upper: String) = s"""$packageName;version="[$lower,$upper)""""

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import com.typesafe.sbt.osgi.SbtOsgi
+import com.typesafe.sbt.osgi.SbtOsgi.autoImport._
 import sbtrelease.ReleasePlugin
 import com.typesafe.sbt.pgp.PgpKeys.publishSigned
 
@@ -24,7 +25,13 @@ lazy val sslConfigCore = project.in(file("ssl-config-core"))
       }),
     osgiSettings,
     OsgiKeys.bundleSymbolicName := s"${organization.value}.sslconfig",
-    OsgiKeys.exportPackage := Seq(s"com.typesafe.sslconfig.*;version=${version.value}")
+    OsgiKeys.exportPackage := Seq(s"com.typesafe.sslconfig.*;version=${version.value}"),
+    OsgiKeys.requireBundle := (
+      scalaBinaryVersion.value match {
+        case "2.10" => Nil
+        case _ => Seq(s"""org.scala-lang.modules.scala-parser-combinators;bundle-version="${Version.parserCombinators}"""")
+      }
+    )
   ).enablePlugins(ReleasePlugin, SbtOsgi)
 
 lazy val documentation = project.in(file("documentation"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 addSbtPlugin("com.github.gseitz"    % "sbt-release"         % "1.0.1")
 addSbtPlugin("com.typesafe.sbt"     % "sbt-native-packager" % "1.0.0")
+addSbtPlugin("com.typesafe.sbt"     % "sbt-osgi"            % "0.8.0")
 addSbtPlugin("com.typesafe.sbt"     % "sbt-s3"              % "0.8")
 addSbtPlugin("com.typesafe.sbt"     % "sbt-scalariform"     % "1.3.0")
 addSbtPlugin("com.typesafe.sbt"     % "sbt-site"            % "0.8.2")


### PR DESCRIPTION
These changes introduce sbt-osgi plugin to create OSGi compliant manifest files.
The bundles are named as referenced from akka-stream:
* com.typesafe.sslconfig
* com.typesafe.sslconfig.akka

For me the descriptors work in an existing project using Eclipse's OSGi container.

Enjoy,
Enno.