### PR TITLE
dbuild relies on onLoad to extract dependencies

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -37,8 +37,6 @@ object Common extends AutoPlugin {
       updateOptions := updateOptions.value.withCachedResolution(true),
       scalacOptions ++= Seq("-encoding", "UTF-8", "-target:jvm-1.6", "-unchecked", "-deprecation", "-feature"),
       javacOptions ++= Seq("-encoding", "UTF-8", "-source", "1.6", "-target", "1.6"),
-      // disable Reactive Platform subscription and version checks
-      onLoad in Global := identity,
       // Scalariform settings
       ScalariformKeys.preferences := ScalariformKeys.preferences.value
         .setPreference(AlignSingleLineCaseStatements, true)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,3 @@ addSbtPlugin("com.typesafe.sbt"     % "sbt-scalariform"     % "1.3.0")
 addSbtPlugin("com.typesafe.sbt"     % "sbt-site"            % "0.8.2")
 addSbtPlugin("com.typesafe.tmp"     % "sbt-header"          % "1.5.0-JDK6-0.1")
 addSbtPlugin("com.jsuereth"         % "sbt-pgp"             % "1.0.0")
-
-// disable Reactive Platform subscription and version checks
-onLoad in Global := identity


### PR DESCRIPTION
needed for the Scala community build

I assume this RP stuff is just old cruft that isn't appropriate to
even have anymore...?  I could be wrong, of course...